### PR TITLE
Stack-Based Approach to Detect 132 Pattern

### DIFF
--- a/132_Pattern.cpp
+++ b/132_Pattern.cpp
@@ -1,0 +1,22 @@
+class Solution {
+public:
+    bool find132pattern(vector<int>& nums) 
+    {
+        ios_base::sync_with_stdio(false);
+        cin.tie(0); cout.tie(0);
+        stack<int> st;
+        int n=nums.size();
+        int prev=INT_MIN;
+        for(int i=n-1;i>=0;i--)
+        {
+            if(nums[i]<prev) return true;
+            while(!st.empty() && st.top()<nums[i])
+            {
+                prev=st.top();
+                st.pop();
+            }
+            st.push(nums[i]);
+        }
+        return false;
+    }
+};


### PR DESCRIPTION

### Intuition
We are looking for a subsequence in the array that follows the 132 pattern: a sequence where there exists indices `i < j < k` such that `nums[i] < nums[k] < nums[j]`. The key is to track the largest '2' in the 132 pattern using a stack.

### Approach
1. Traverse the array in reverse (starting from the rightmost element).
2. Use a stack to keep track of potential '3' values in the 132 pattern.
3. Maintain a variable `prev` to store the most recent valid '2' found in the sequence.
4. For each element `nums[i]`, check if it is less than the current `prev` ('2'). If yes, we've found a valid 132 pattern.
5. Update `prev` by popping from the stack, ensuring we always have the largest possible '2'.
6. Push the current element into the stack as a potential '3'.

### Complexity
- **Time complexity**:  
  The time complexity is \( O(n) \), where \( n \) is the size of the input array. Each element is pushed and popped from the stack at most once.
  
- **Space complexity**:  
  The space complexity is \( O(n) \) in the worst case, due to the space used by the stack.

